### PR TITLE
fix(package): compatibility w/latest react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fs": "0.0.2",
     "path": "^0.11.14",
     "process": "^0.10.1",
-    "react-native": "^0.3.11",
+    "react-native": "^0.4.1",
     "stream": "0.0.2",
     "tiny-queue": "0.2.0",
     "util": "^0.10.3"


### PR DESCRIPTION
Depending on `react-native@0.3.x` breaks the debugger-ui, when the app using this module is running `react-native@0.4.x`.
