### PR TITLE
Update abstract-leveldown dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
 
 // require('./platform');
 var inherits = require('util').inherits;
-var AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN;
-var AbstractIterator = require('abstract-leveldown').AbstractIterator;
+var ALD = require('abstract-leveldown');
+var AbstractLevelDOWN = ALD.AbstractLevelDOWN;
+var AbstractIterator = ALD.AbstractIterator;
 
 var Storage = require('./asyncstorage').Storage;
 var StorageCore = require('./asyncstorage-core');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "2.4.0",
   "main": "index.js",
   "dependencies": {
-    "abstract-leveldown": "0.12.3",
+    "abstract-leveldown": "2.4.1",
     "argsarray": "0.0.1",
     "d64": "^1.0.0",
     "tiny-queue": "0.2.0"


### PR DESCRIPTION
The version that is currently in use does not work in the latest react-native for some reason?
This fixed it for me...
