### PR TITLE
Fix key comparison, ranges, and enable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This project is intended for use with the [level eco-system](https://github.com/
 npm install asyncstorage-down
 ```
 
-## Example 
+## Example
 
-At the command prompt in your chosen directory : 
+At the command prompt in your chosen directory :
 
 ```
 npm install asyncstorage-down
-npm install levelup 
+npm install levelup
 ```
 
 Create a file called index.js and enter the following:
@@ -52,10 +52,6 @@ db.readStream()
    });
 ```
 
-## Tests
-
-_TODO: tests pass, but still need to setup env for automatic testing_
-
 ## Note
 
 React Native's packager currently doesn't automatically inject browserified core node modules, like util, crypto, process, buffer, etc. Currently this module depends on several shims to mitigate the sadness. The alternative is to use [react-native-webpack-server](https://www.npmjs.org/package/react-native-webpack-server), which allows you to use browserified node core modules out of the box. Once React Native's packager allows the same functionality, this module's dependencies can be heavily pruned.
@@ -67,6 +63,8 @@ Tradle, Inc. https://github.com/tradle
 Mark Vayngrib https://github.com/mvayngrib
 
 Ellen Katsnelson https://github.com/pgmemk
+
+Andre Staltz https://github.com/staltz
 
 ## localstorage-down Contributors
 

--- a/asyncstorage.js
+++ b/asyncstorage.js
@@ -41,7 +41,7 @@ Storage.prototype.setItems = function (pairs, callback) {
     for (var i = 0 ; i < pairs.length; i++) {
       var key = pairs[i][0]
       var idx = utils.sortedIndexOf(self._keys, key);
-      if (self._keys[idx] !== key) {
+      if (utils.keyNeq(self._keys[idx], key)) {
         self._keys.splice(idx, 0, key);
       }
     }
@@ -74,7 +74,7 @@ Storage.prototype.getItems = function (keys, callback) {
     for (var i = 0; i < encoded.length; i++) {
       var key = encoded[i]
       var idx = utils.sortedIndexOf(myKeys, key)
-      if (myKeys[idx] !== key) {
+      if (utils.keyNeq(myKeys[idx], key)) {
         allErrs[i] = new Error('NotFound')
       } else {
         allErrs[i] = undefined
@@ -126,7 +126,7 @@ Storage.prototype.removeItems = function (keys, callback) {
   self.sequentialize(callback, function (callback) {
     keys.forEach((key) => {
       var idx = utils.sortedIndexOf(self._keys, key);
-      if (self._keys[idx] === key) {
+      if (utils.keyEq(self._keys[idx], key)) {
         self._keys.splice(idx, 1);
       }
     })

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var AbstractIterator = require('abstract-leveldown').AbstractIterator;
 var Storage = require('./asyncstorage').Storage;
 var StorageCore = require('./asyncstorage-core');
 var utils = require('./utils');
+var ltgt = require('ltgt');
 
 // see http://stackoverflow.com/a/15349865/680742
 var nextTick = global.setImmediate || process.nextTick;
@@ -24,79 +25,149 @@ function ADIterator(db, options) {
   this._gte     = options.gte;
   this._lt      = options.lt;
   this._lte     = options.lte;
+  this._keyAsBuffer = options.keyAsBuffer;
+  this._valueAsBuffer = options.valueAsBuffer;
   this._exclusiveStart = options.exclusiveStart;
   this._limit = options.limit;
   this._keysOnly = options.values === false
   this._count = 0;
-  this._cache = []
+  this._cache = [];
+  this._cacheExtinguished = false;
 
   this.onInitCompleteListeners = [];
+
+  this.initStarted = true;
+  var self = this;
+  this.db.container.keys(function (err, keys) {
+    if (err) {
+      self.initError = err;
+    }
+
+    self._keys = keys;
+    if (!self._reverse) {
+      self._startkey = ltgt.lowerBound(options)
+      self._endkey = ltgt.upperBound(options)
+    } else {
+      self._startkey = ltgt.upperBound(options)
+      self._endkey = ltgt.lowerBound(options)
+    }
+    if (self._startkey) {
+      var index = utils.sortedIndexOf(self._keys, self._startkey);
+      var startkey = (index >= self._keys.length || index < 0)
+        ? undefined
+        : self._keys[index];
+
+      self._pos = index;
+      if (self._reverse) {
+        if (self._lt && startkey === self._lt) {
+          self._pos--;
+        } else if (self._exclusiveStart || startkey !== self._startkey) {
+          self._pos--;
+        }
+      } else if (self._gt && startkey === self._gt) {
+        self._pos++;
+      } else if (self._exclusiveStart && startkey === self._startkey) {
+        self.pos++;
+      }
+    } else {
+      self._pos = self._reverse ? self._keys.length - 1 : 0;
+    }
+
+    self._fillCache(function () {
+      self.initCompleted = true;
+
+      var i = -1;
+      while (++i < self.onInitCompleteListeners.length) {
+        nextTick(self.onInitCompleteListeners[i]);
+      }
+    })
+  });
 }
 
 inherits(ADIterator, AbstractIterator);
 
-ADIterator.prototype._init = function (callback) {
-  nextTick(callback)
-};
+ADIterator.prototype._fillCache = function fillCache(callback) {
+  var batch = []
+  for (var i = 0; i < batchSize; i++) {
+    if (this._limit === 0) {
+      break;
+    }
+    if (this._pos === this._keys.length || this._pos < 0) { // done reading
+      break;
+    }
+
+    var key = this._keys[this._pos];
+
+    if (!!this._limit && this._limit > 0 && this._count++ >= this._limit) {
+      break;
+    }
+
+    if (!!this._endkey && (this._reverse ? key < this._endkey : key > this._endkey)) {
+      break;
+    }
+
+    if ((this._lt  && key >= this._lt) ||
+      (this._lte && key > this._lte) ||
+      (this._gt  && key <= this._gt) ||
+      (this._gte && key < this._gte)) {
+      break;
+    }
+
+    this._pos += this._reverse ? -1 : 1;
+    batch.push(key)
+  }
+
+  if (!batch.length) {
+    this._cache = []
+    this._cacheExtinguished = true;
+    return callback()
+  }
+
+  if (this._keysOnly) {
+    this._cache = batch
+    return callback()
+  }
+
+  var self = this;
+  this.db.container.getItems(batch, function (errs, values) {
+    self._cache = values.map(function (v, idx) {
+      return {
+        key: batch[idx],
+        value: v,
+        error: errs[idx]
+      }
+    })
+    callback()
+  });
+}
 
 ADIterator.prototype._next = function (callback) {
   var self = this;
   callback = asyncify(callback)
 
-  if (self.initStarted) {
-    if (self.initCompleted) {
-      onInitComplete();
-    } else {
-      self.onInitCompleteListeners.push(onInitComplete);
-    }
-
-    return
+  if (self.initError) {
+    callback(self.initError);
+    return;
   }
 
-  self.initStarted = true;
-  self._init(function (err) {
-    if (err) {
-      return callback(err);
+  if (self.initStarted) {
+    if (self.initCompleted) {
+      getFromCache();
+    } else {
+      self.onInitCompleteListeners.push(getFromCache);
     }
-    self.db.container.keys(function (err, keys) {
-      if (err) {
-        return callback(err);
-      }
+    return;
+  }
 
-      self._keys = keys;
-      if (self._startkey) {
-        var index = utils.sortedIndexOf(self._keys, self._startkey);
-        var startkey = (index >= self._keys.length || index < 0)
-          ? undefined
-          : self._keys[index];
+  function getFromCache() {
+    if (self._cacheExtinguished) {
+      return callback()
+    }
 
-        self._pos = index;
-        if (self._reverse) {
-          if (self._exclusiveStart || startkey !== self._startkey) {
-            self._pos--;
-          }
-        } else if (self._exclusiveStart && startkey === self._startkey) {
-          self._pos++;
-        }
-      } else {
-        self._pos = self._reverse ? self._keys.length - 1 : 0;
-      }
-
-      onInitComplete();
-
-      self.initCompleted = true;
-      var i = -1;
-      while (++i < self.onInitCompleteListeners.length) {
-        nextTick(self.onInitCompleteListeners[i]);
-      }
-    });
-  });
-
-  function onInitComplete() {
     if (self._cache.length) {
       var cached = self._cache.shift()
       if (self._keysOnly) {
-        return callback(null, cached)
+        return callback(null, self._keyAsBuffer ? new Buffer(cached) : cached)
       }
 
       if (cached.error) {
@@ -109,58 +180,13 @@ ADIterator.prototype._next = function (callback) {
         }
       }
 
-      callback(null, cached.key, cached.value)
+      callback(null,
+        self._keyAsBuffer ? new Buffer(cached.key) : cached.key,
+        self._valueAsBuffer ? new Buffer(cached.value) : cached.value)
       return
+    } else {
+      self._fillCache(getFromCache)
     }
-
-    var batch = []
-    for (var i = 0; i < batchSize; i++) {
-      if (self._pos === self._keys.length || self._pos < 0) { // done reading
-        break;
-      }
-
-      var key = self._keys[self._pos];
-
-      if (!!self._endkey && (self._reverse ? key < self._endkey : key > self._endkey)) {
-        break;
-      }
-
-      if (!!self._limit && self._limit > 0 && self._count++ >= self._limit) {
-        break;
-      }
-
-      if ((self._lt  && key >= self._lt) ||
-        (self._lte && key > self._lte) ||
-        (self._gt  && key <= self._gt) ||
-        (self._gte && key < self._gte)) {
-        break;
-      }
-
-      self._pos += self._reverse ? -1 : 1;
-      batch.push(key)
-    }
-
-    if (!batch.length) {
-      self._cache = []
-      return callback()
-    }
-
-    if (self._keysOnly) {
-      self._cache = batch
-      return onInitComplete()
-    }
-
-    self.db.container.getItems(batch, function (errs, values) {
-      self._cache = values.map(function (v, idx) {
-        return {
-          key: batch[idx],
-          value: v,
-          error: errs[idx]
-        }
-      })
-
-      onInitComplete()
-    });
   }
 };
 
@@ -185,11 +211,15 @@ AD.prototype._multiPut = function (pairs, options, callback) {
     err = checkKeyValue(key, 'key');
     if (err) return
 
-    err = checkKeyValue(value, 'value');
+    if (checkKeyValue(value, 'value')) {
+      normalized.push([key, ''])
+      return true
+    }
 
-    if (err) return
-
-    if (typeof value === 'object' && !Buffer.isBuffer(value) && value.buffer === undefined) {
+    if (value !== null
+    && typeof value === 'object'
+    && !Buffer.isBuffer(value)
+    && value.buffer === undefined) {
       var obj = {};
       obj.storetype = 'json';
       obj.data = value;
@@ -223,7 +253,6 @@ AD.prototype._get = function (key, options, callback) {
   }
 
   this.container.getItem(key, function (err, value) {
-
     if (err) {
       return callback(err);
     }
@@ -231,7 +260,6 @@ AD.prototype._get = function (key, options, callback) {
     if (options.asBuffer !== false && !Buffer.isBuffer(value)) {
       value = new Buffer(value);
     }
-
 
     if (options.asBuffer === false) {
       if (value.indexOf('{"storetype":"json","data"') > -1) {
@@ -244,25 +272,30 @@ AD.prototype._get = function (key, options, callback) {
 };
 
 AD.prototype._multiDel = function (keys, options, callback) {
-  var normalized = []
-  var err
-  keys.every((key) => {
-    err = checkKeyValue(key, 'key');
-    if (err) return
+  // Next tick so that any ADIterator has had enough time to make a snapshot.
+  // This is for sure a crappy solution, but neither iterator snapshot nor
+  // delete seem to be timely/urgent features. PRs welcomed :D
+  nextTick(() => {
+    var normalized = []
+    var err
+    keys.every((key) => {
+      err = checkKeyValue(key, 'key');
+      if (err) return
 
-    if (!Buffer.isBuffer(key)) {
-      key = String(key);
+      if (!Buffer.isBuffer(key)) {
+        key = String(key);
+      }
+
+      normalized.push(key)
+      return true
+    })
+
+    if (err) {
+      nextTick(() => callback(err))
+    } else {
+      this.container.removeItems(keys, callback)
     }
-
-    normalized.push(key)
-    return true
   })
-
-  if (err) {
-    nextTick(() => callback(err))
-  } else {
-    this.container.removeItems(keys, callback)
-  }
 }
 
 AD.prototype._del = function (key, options, callback) {
@@ -297,9 +330,8 @@ AD.prototype._batch = function (array, options, callback) {
         toDel.push(task.key)
       } else if (task.type === 'put') {
         value = Buffer.isBuffer(task.value) ? task.value : String(task.value);
-        err = checkKeyValue(value, 'value');
-        if (err) {
-          return callback(err);
+        if (checkKeyValue(value, 'value')) {
+          toPut.push([key, ''])
         } else {
           toPut.push([key, value])
         }
@@ -347,25 +379,17 @@ function checkKeyValue(obj, type) {
   if (obj === null || obj === undefined) {
     return new Error(type + ' cannot be `null` or `undefined`');
   }
-  if (obj === null || obj === undefined) {
-    return new Error(type + ' cannot be `null` or `undefined`');
+  if (obj instanceof Boolean) {
+    return new Error(type + ' cannot be a boolean');
   }
-
-  if (type === 'key') {
-
-    if (obj instanceof Boolean) {
-      return new Error(type + ' cannot be `null` or `undefined`');
-    }
-    if (obj === '') {
-      return new Error(type + ' cannot be empty');
-    }
+  if (obj === '') {
+    return new Error(type + ' cannot be an empty string');
   }
   if (obj.toString().indexOf('[object ArrayBuffer]') === 0) {
     if (obj.byteLength === 0 || obj.byteLength === undefined) {
       return new Error(type + ' cannot be an empty Buffer');
     }
   }
-
   if (Buffer.isBuffer(obj)) {
     if (obj.length === 0) {
       return new Error(type + ' cannot be an empty Buffer');

--- a/index.js
+++ b/index.js
@@ -14,30 +14,6 @@ var ltgt = require('ltgt');
 var nextTick = global.setImmediate || process.nextTick;
 var batchSize = 20
 
-function keyEq(k1, k2) {
-  return (k1 || '').toString('hex') === (k2 || '').toString('hex');
-}
-
-function keyNeq(k1, k2) {
-  return (k1 || '').toString('hex') !== (k2 || '').toString('hex');
-}
-
-function keyGt(k1, k2) {
-  return (k1 || '').toString('hex') > (k2 || '').toString('hex');
-}
-
-function keyGte(k1, k2) {
-  return (k1 || '').toString('hex') >= (k2 || '').toString('hex');
-}
-
-function keyLt(k1, k2) {
-  return (k1 || '').toString('hex') < (k2 || '').toString('hex');
-}
-
-function keyLte(k1, k2) {
-  return (k1 || '').toString('hex') <= (k2 || '').toString('hex');
-}
-
 function ADIterator(db, options) {
 
   AbstractIterator.call(this, db);
@@ -85,13 +61,13 @@ function ADIterator(db, options) {
           if (self._pos === self._keys.length) {
             self._pos--;
           }
-          else if (self._lt && keyGte(self._keys[self._pos], self._lt)) {
+          else if (self._lt && utils.keyGte(self._keys[self._pos], self._lt)) {
             self._pos--;
           }
-          else if (self._lte && keyGt(self._keys[self._pos], self._lte)) {
+          else if (self._lte && utils.keyGt(self._keys[self._pos], self._lte)) {
             self._pos--;
           }
-          else if (!self._lt && keyGt(self._keys[self._pos], self._startkey)) {
+          else if (!self._lt && utils.keyGt(self._keys[self._pos], self._startkey)) {
             self._pos--;
           }
         }
@@ -99,13 +75,13 @@ function ADIterator(db, options) {
           if (self._pos < 0) {
             self._pos = 0;
           }
-          else if (self._gt && keyLte(self._keys[self._pos], self._gt)) {
+          else if (self._gt && utils.keyLte(self._keys[self._pos], self._gt)) {
             self._pos++;
           }
-          else if (self._gte && keyLt(self._keys[self._pos], self._gt)) {
+          else if (self._gte && utils.keyLt(self._keys[self._pos], self._gt)) {
             self._pos++;
           }
-          else if (!self._gt && keyLt(self._keys[self._pos], self._startkey)) {
+          else if (!self._gt && utils.keyLt(self._keys[self._pos], self._startkey)) {
             self._pos++;
           }
         }
@@ -115,10 +91,10 @@ function ADIterator(db, options) {
 
       if (self._endkey) {
         self._endIndex = utils.sortedIndexOf(self._keys, self._endkey);
-        if (self._reverse && keyLt(self._keys[self._endIndex], self._endkey)) {
+        if (self._reverse && utils.keyLt(self._keys[self._endIndex], self._endkey)) {
           self._endIndex++;
         }
-        else if (!self._reverse && keyGt(self._keys[self._endIndex], self._endkey)) {
+        else if (!self._reverse && utils.keyGt(self._keys[self._endIndex], self._endkey)) {
           self._endIndex--;
         }
       }
@@ -158,10 +134,10 @@ ADIterator.prototype._fillCache = function fillCache(callback) {
       break;
     }
 
-    if ((this._lt && keyGte(key, this._lt))
-    || (this._lte && keyGt(key, this._lte))
-    || (this._gt  && keyLte(key, this._gt))
-    || (this._gte && keyLt(key, this._gte))) {
+    if ((this._lt && utils.keyGte(key, this._lt))
+    || (this._lte && utils.keyGt(key, this._lte))
+    || (this._gt  && utils.keyLte(key, this._gt))
+    || (this._gte && utils.keyLt(key, this._gte))) {
       break;
     }
 

--- a/mock-react-native/index.js
+++ b/mock-react-native/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  AsyncStorage: require('asyncstorage-mock-another')
+}

--- a/mock-react-native/package.json
+++ b/mock-react-native/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react-native",
+  "description": "A fake React Native package to contain the mock for AsyncStorage",
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "asyncstorage-mock-another": "^1.0.1",
     "react-native": "file:./mock-react-native",
     "levelup": "^0.18.2",
-    "tape": "^2.12.3"
+    "tape": "^4.6.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "tiny-queue": "0.2.0"
   },
   "devDependencies": {
+    "asyncstorage-mock-another": "^1.0.1",
+    "react-native": "file:./mock-react-native",
     "levelup": "^0.18.2",
     "tape": "^2.12.3"
   },
@@ -28,7 +30,7 @@
     "url": "https://github.com/tradle/asyncstorage-down.git"
   },
   "scripts": {
-    "test": "echo 'TODO: run tests with xctool'"
+    "test": "node test/test.js"
   },
   "license": "MIT",
   "gypfile": false

--- a/package.json
+++ b/package.json
@@ -14,15 +14,16 @@
   "version": "3.1.1",
   "main": "index.js",
   "dependencies": {
-    "abstract-leveldown": "0.12.3",
+    "abstract-leveldown": "2.6.1",
     "argsarray": "0.0.1",
     "d64": "^1.0.0",
+    "ltgt": "^2.1.3",
     "tiny-queue": "0.2.0"
   },
   "devDependencies": {
     "asyncstorage-mock-another": "^1.0.1",
+    "levelup": "^1.3.0",
     "react-native": "file:./mock-react-native",
-    "levelup": "^0.18.2",
     "tape": "^4.6.3"
   },
   "repository": {

--- a/test/testCommon.js
+++ b/test/testCommon.js
@@ -11,7 +11,7 @@ var lastLocation = function () {
 
 var cleanup = function (callback) {
 
-  if (window.localStorage) {
+  if (typeof window !== 'undefined' && window.localStorage) {
     window.localStorage.clear();
   }
 

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,37 @@ var d64 = require('d64');
 var nonBufferPrefix = 'n:'
 var bufferPrefix = 'b:'
 
+function keyEq(k1, k2) {
+  return (k1 || '').toString('hex') === (k2 || '').toString('hex');
+}
+
+function keyNeq(k1, k2) {
+  return (k1 || '').toString('hex') !== (k2 || '').toString('hex');
+}
+
+function keyGt(k1, k2) {
+  return (k1 || '').toString('hex') > (k2 || '').toString('hex');
+}
+
+function keyGte(k1, k2) {
+  return (k1 || '').toString('hex') >= (k2 || '').toString('hex');
+}
+
+function keyLt(k1, k2) {
+  return (k1 || '').toString('hex') < (k2 || '').toString('hex');
+}
+
+function keyLte(k1, k2) {
+  return (k1 || '').toString('hex') <= (k2 || '').toString('hex');
+}
+
+exports.keyEq = keyEq;
+exports.keyNeq = keyNeq;
+exports.keyGt = keyGt;
+exports.keyGte = keyGte;
+exports.keyLt = keyLt;
+exports.keyLte = keyLte;
+
 // taken from rvagg/memdown commit 2078b40
 exports.sortedIndexOf = function(arr, item) {
   var low = 0;
@@ -11,7 +42,7 @@ exports.sortedIndexOf = function(arr, item) {
   var mid;
   while (low < high) {
     mid = (low + high) >>> 1;
-    if (arr[mid] < item) {
+    if (keyLt(arr[mid], item)) {
       low = mid + 1;
     } else {
       high = mid;
@@ -19,7 +50,6 @@ exports.sortedIndexOf = function(arr, item) {
   }
   return low;
 };
-
 
 exports.encode = function encode (vals) {
   return Array.isArray(vals) ? vals.map(encodeOne) : encodeOne(vals)


### PR DESCRIPTION
This PR

- Updates abstract-leveldown to v2.6.1
- Fixes the tests by mocking react native (just run `npm test`)
- Fixes logic in index.js related to keys, their comparisons, to correctly implement ranges

I'm intending to publish this independently to npm under `@staltz/asyncstorage-down` because I really need it. It would be nice though to have the fixes pushed to this repo and package too, though.