### PR TITLE
only call `multiRemove` if there are keys to remove in `destroy` method

### DIFF
--- a/asyncstorage-core.js
+++ b/asyncstorage-core.js
@@ -91,9 +91,11 @@ AsyncStorageCore.destroy = function (dbname, callback) {
       return key.slice(0, prefixLen) === prefix;
     })
 
-    if (keys.length) {
-      AsyncStorage.multiRemove(keys, callback);
+    if (!keys.length) {
+      return callback()
     }
+
+    AsyncStorage.multiRemove(keys, callback);
   })
 };
 

--- a/asyncstorage-core.js
+++ b/asyncstorage-core.js
@@ -91,7 +91,9 @@ AsyncStorageCore.destroy = function (dbname, callback) {
       return key.slice(0, prefixLen) === prefix;
     })
 
-    AsyncStorage.multiRemove(keys, callback);
+    if (keys.length) {
+      AsyncStorage.multiRemove(keys, callback);
+    }
   })
 };
 


### PR DESCRIPTION
This ensures that `multiRemove` is only called if there are at least one key in the `keys` array.

An empty array results in the error `Array [ [Error: Invalid key] ]`