### PR TITLE
Add reference to react-native-leveldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ db.readStream()
 
 React Native's packager currently doesn't automatically inject browserified core node modules, like util, crypto, process, buffer, etc. Currently this module depends on several shims to mitigate the sadness. The alternative is to use [react-native-webpack-server](https://www.npmjs.org/package/react-native-webpack-server), which allows you to use browserified node core modules out of the box. Once React Native's packager allows the same functionality, this module's dependencies can be heavily pruned.
 
+## Alternatives
+
+If you're willing to add native modules to your project, you may also be interested in [`react-native-leveldown`](https://github.com/andymatuschak/react-native-leveldown), which implements native bindings to the original C++ implementation of LevelDB (currently only for iOS/Mac).
+
 ## Contributors
 
 Tradle, Inc. https://github.com/tradle


### PR DESCRIPTION
Hi, all! My project has some intense data requirements, so [I've implemented a new library](https://github.com/andymatuschak/react-native-leveldown) providing native RN bindings to the original C++ LevelDB (currently iOS/Mac only).

In my Readme, I link to `asyncstorage-down` as an alternative for folks who don't want to add native modules to their project. I wondered if you all might be up for linking to my implementation for people who are interested in a native implementation? No worries if not—I'm mostly hoping to attract the help of someone who might feel like implementing the Android shim. :)