### PR TITLE
replace RN AsyncStorage with community package

### DIFF
--- a/default-opts.js
+++ b/default-opts.js
@@ -1,5 +1,5 @@
 module.exports = {
   get AsyncStorage() {
-    return require('react-native').AsyncStorage
+    return require('@react-native-community/async-storage').default
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^5.9.0",
     "husky": "^1.1.3",
     "levelup": "^1.3.0",
-    "react-native": "file:./mock-react-native",
+    "@react-native-community/async-storage": "file:./mock-react-native",
     "tape": "^4.6.3"
   },
   "repository": {


### PR DESCRIPTION
fixes #10 

Avoids the warning because of the usage of ReactNative.AsyncStorage