### PR TITLE
Fix/async  library deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Create a file called index.js and enter the following:
 import asyncstorageDown from 'asyncstorage-down'
 import levelup from 'levelup'
 // or whichever implementation you're using
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const db = levelup('/does/not/matter', {
   db: location => asyncstorageDown(location, { AsyncStorage })

--- a/default-opts.js
+++ b/default-opts.js
@@ -1,5 +1,5 @@
 module.exports = {
   get AsyncStorage() {
-    return require('react-native').AsyncStorage
+    return require('@react-native-async-storage/async-storage').AsyncStorage
   }
 }

--- a/default-opts.js
+++ b/default-opts.js
@@ -1,5 +1,5 @@
 module.exports = {
   get AsyncStorage() {
-    return require('@react-native-async-storage/async-storage').AsyncStorage
+    return require('@react-native-async-storage/async-storage').default
   }
 }

--- a/mock-react-native/package.json
+++ b/mock-react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native",
+  "name": "@react-native-async-storage/async-storage",
   "description": "A fake React Native package to contain the mock for AsyncStorage",
   "version": "0.0.0",
   "main": "index.js"

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "tiny-queue": "0.2.0"
   },
   "devDependencies": {
+    "@react-native-async-storage/async-storage": "file:./mock-react-native",
     "asyncstorage-mock-another": "^1.0.1",
     "eslint": "^5.9.0",
     "husky": "^1.1.3",
     "levelup": "^1.3.0",
-    "react-native": "file:./mock-react-native",
     "tape": "^4.6.3"
   },
   "repository": {


### PR DESCRIPTION
React-Native AsyncStorage has been deprecated. This is updating to the new library.